### PR TITLE
#6 extends Transform to build Kvs parser

### DIFF
--- a/lib/kvs-stream.js
+++ b/lib/kvs-stream.js
@@ -1,12 +1,14 @@
-const {Readable} = require('stream');
+const {Transform} = require('stream');
 const AWS = require('aws-sdk');
 const {EbmlStreamDecoder} = require('ebml-stream');
-const rootTagEncoder = require('./utils/root-tag-encoder.js');
+
+const rootTagTransform = require('./utils/root-tag-transform.js');
+
 /**
  * KvsStream parse the AWS Kinesis video stream.
  * This class uses the (ebml-stream)[https://www.npmjs.com/package/ebml-stream] library to parse the MKV Information
 */
-class KvsStream extends Readable {
+class KvsStream extends Transform {
 	/**
 	 * Constructor will getMediaParams and awsInstances as Input.
 	 * @throws Will throw an error if the getMediaParams is null.
@@ -16,42 +18,31 @@ class KvsStream extends Readable {
 	 * new KvsStream({ StartSelector: { StartSelectorType: 'FRAGMENT_NUMBER | SERVER_TIMESTAMP | PRODUCER_TIMESTAMP | NOW | EARLIEST | CONTINUATION_TOKEN'}, StreamName: streamName.})
 	*/
 	constructor(getMediaParameters, awsInstances = {}) {
-		super({objectMode: true});
-		this.kinesisvideo = awsInstances.kinesisvideo || new AWS.KinesisVideo();
-		this.kinesisvideomedia = awsInstances.kinesisvideomedia || new AWS.KinesisVideoMedia();
+		// Memory used to list the number of open main tags in the stream
+		const openMainTags = [];
 
-		const request = this.kinesisvideomedia.getMedia(getMediaParameters);
-		const ebmlDecoder = new EbmlStreamDecoder();
-		this.requestStream = request.createReadStream();
-		const decodedStream = this.requestStream.pipe(ebmlDecoder);
-		this.videoFragmentStream = decodedStream.pipe(rootTagEncoder);
-	}
-
-	_read() {
-		/**
-		 * Data event.
-		 * Returns the parsed stream data
-		 * @event KvsStream#data
-		 * @type {EbmlTag} see https://www.npmjs.com/package/ebml-stream
-		*/
-		this.videoFragmentStream.on('data', fragment => {
-			this.push(fragment);
+		super({
+			transform: rootTagTransform.bind(null, openMainTags),
+			readableObjectMode: true,
+			writableObjectMode: true,
 		});
 
-		/**
-		 * End event.
-		 * @event KvsStream#end
-		*/
-		this.videoFragmentStream.on('end', _ => {
-			this.push(null);
-		});
+		this.connectToKvs(getMediaParameters, awsInstances);
 	}
 
-	_destroy() {
-		this.kinesisvideo = null;
-		this.kinesisvideomedia = null;
-		this.requestStream = null;
-		this.videoFragmentStream = null;
+	connectToKvs(getMediaParameters, awsInstances) {
+		const kinesisvideo = awsInstances.kinesisvideo || new AWS.KinesisVideo();
+		const kinesisvideomedia = awsInstances.kinesisvideomedia || new AWS.KinesisVideoMedia();
+		return kinesisvideo.getDataEndPoint().promise().then(({DataEndPoint}) => {
+			kinesisvideomedia.endpoint = DataEndPoint;
+			const request = kinesisvideomedia.getMedia(getMediaParameters);
+			const requestStream = request.createReadStream();
+
+			const ebmlDecoder = new EbmlStreamDecoder();
+			const decodedStream = requestStream.pipe(ebmlDecoder);
+
+			decodedStream.pipe(this);
+		});
 	}
 }
 module.exports = KvsStream;

--- a/lib/utils/root-tag-transform.js
+++ b/lib/utils/root-tag-transform.js
@@ -1,8 +1,6 @@
-const {Transform} = require('stream');
 const {EbmlTagId} = require('ebml-stream');
 // Memory of the current video fragment
 // should empty itself automatically
-const openMainTags = [];
 
 const safeDepthLimit = 100;
 
@@ -11,7 +9,7 @@ for (const k of Object.keys(EbmlTagId)) {
 	reverseTagId[EbmlTagId[k]] = k;
 }
 
-function transform(ebmlTag, enc, cb) {
+module.exports = function (openMainTags, ebmlTag, enc, cb) {
 	const {id, position, type} = ebmlTag;
 	const tagTypeName = reverseTagId[id];
 	ebmlTag.idName = tagTypeName;
@@ -58,10 +56,4 @@ function transform(ebmlTag, enc, cb) {
 	}
 
 	cb(error, chunk);
-}
-
-module.exports = new Transform({
-	transform,
-	readableObjectMode: true,
-	writableObjectMode: true,
-});
+};

--- a/test/mock/kinesisvideo.js
+++ b/test/mock/kinesisvideo.js
@@ -1,8 +1,10 @@
 const kinesisvideo = {
 	getDataEndPoint() {
 		return {
-			data: {
-				DataEndPoint: 'https://fakeurl',
+			promise() {
+				return Promise.resolve({
+					DataEndPoint: 'https://fakeurl',
+				});
 			},
 		};
 	},


### PR DESCRIPTION
@dharmik-dalwadi-seaflux i have changed following points in implementation : 

* Now kvsStream extends Transform class, which let use connect it directly to the decoderStream inside the constructor, it let us avoid re-writing the _read and _destroy methods manually
* I have added openMainTags as input of [root-tag-transform.js](https://github.com/alezanai/kvs-parser/pull/10/files#diff-cb479c29e2fac83d2a38c7d01d82ebce2dc803d30509a38da7feb808ff5f71f8) and i'm setting this input using `.bind(null, openMainTags)` see [here](https://github.com/alezanai/kvs-parser/blob/9b890d58e4e4e5e7a23ab1356d5a12853ac7664a/lib/kvs-stream.js#L25), i will explain on slack if not clear

I feel this implementation is more clean since error event, data event, close event ... will be piped automatically into the KvsStream without having to write any code using the "pipe" mechanisme of streams